### PR TITLE
[wetek] Add play2 and unify stb_type to WETEK for all devices

### DIFF
--- a/main.c
+++ b/main.c
@@ -154,9 +154,9 @@ void (*resize)(const unsigned char *source, unsigned char *dest, int xsource, in
 void combine(unsigned char *output, const unsigned char *video, const unsigned char *osd, int vleft, int vtop, int vwidth, int vheight, int xres, int yres);
 
 #if !defined(__sh__)
-static enum {UNKNOWN, WETEKPLAY, AZBOX863x, AZBOX865x, PALLAS, VULCAN, XILLEON, BRCM7400, BRCM7401, BRCM7405, BRCM7325, BRCM7335, BRCM7346, BRCM7358, BRCM7362, BRCM7241, BRCM7251, BRCM7252, BRCM7356, BRCM7424, BRCM7425, BRCM7435, BRCM7552, BRCM7581, BRCM7583, BRCM7584, BRCM7366, BRCM73625, BRCM73565} stb_type = UNKNOWN;
+static enum {UNKNOWN, WETEK, AZBOX863x, AZBOX865x, PALLAS, VULCAN, XILLEON, BRCM7400, BRCM7401, BRCM7405, BRCM7325, BRCM7335, BRCM7346, BRCM7358, BRCM7362, BRCM7241, BRCM7251, BRCM7252, BRCM7356, BRCM7424, BRCM7425, BRCM7435, BRCM7552, BRCM7581, BRCM7583, BRCM7584, BRCM7366, BRCM73625, BRCM73565} stb_type = UNKNOWN;
 #else
-static enum {UNKNOWN, WETEKPLAY, AZBOX863x, AZBOX865x, ST, PALLAS, VULCAN, XILLEON, BRCM7400, BRCM7401, BRCM7405, BRCM7325, BRCM7335, BRCM7346, BRCM7358, BRCM7362, BRCM7241, BRCM7251, BRCM7252, BRCM7356, BRCM7424, BRCM7425, BRCM7435, BRCM7552, BRCM7581, BRCM7583, BRCM7584, BRCM7366, BRCM73625, BRCM73565} stb_type = UNKNOWN;
+static enum {UNKNOWN, WETEK, AZBOX863x, AZBOX865x, ST, PALLAS, VULCAN, XILLEON, BRCM7400, BRCM7401, BRCM7405, BRCM7325, BRCM7335, BRCM7346, BRCM7358, BRCM7362, BRCM7241, BRCM7251, BRCM7252, BRCM7356, BRCM7424, BRCM7425, BRCM7435, BRCM7552, BRCM7581, BRCM7583, BRCM7584, BRCM7366, BRCM73625, BRCM73565} stb_type = UNKNOWN;
 #endif
 
 static int chr_luma_stride = 0x40;
@@ -341,9 +341,9 @@ int main(int argc, char **argv)
 					stb_type = BRCM7366;
 					break;
 				}
-				else if (strstr(buf,"Meson-6"))
+				else if (strstr(buf,"Meson-6") || strstr(buf,"Meson-64"))
 				{
-					stb_type = WETEKPLAY;
+					stb_type = WETEK;
 					break;
 				}
 			}
@@ -1099,7 +1099,7 @@ void getvideo(unsigned char *video, int *xres, int *yres)
 			SWAP(p[1], p[2]);
 		}
 	}
-	else if (stb_type == WETEKPLAY)
+	else if (stb_type == WETEK)
 	{
 #define AMVIDEOCAP_IOC_MAGIC  'V'
 #define AMVIDEOCAP_IOW_SET_START_CAPTURE _IOW(AMVIDEOCAP_IOC_MAGIC, 0x32, int)
@@ -1797,10 +1797,10 @@ void getosd(unsigned char *osd, int *xres, int *yres)
 	struct fb_fix_screeninfo fix_screeninfo;
 	struct fb_var_screeninfo var_screeninfo;
 
-	fb=open(stb_type == WETEKPLAY ? "/dev/fb/2" : "/dev/fb/0", O_RDWR);
+	fb=open(stb_type == WETEK ? "/dev/fb/2" : "/dev/fb/0", O_RDWR);
 	if (fb == -1)
 	{
-		fb=open(stb_type == WETEKPLAY ? "/dev/fb2" : "/dev/fb0", O_RDWR);
+		fb=open(stb_type == WETEK ? "/dev/fb2" : "/dev/fb0", O_RDWR);
 		if (fb == -1)
 		{
 			fprintf(stderr, "Framebuffer failed\n");


### PR DESCRIPTION
Hi @atvcaptain ,
can you merge this change for Wetek Play2 and I also unify 'stb_type' to WETEK for all devices because they share the same capture code and no need to expand/complicate code with new stb_type identification for Play2.

Thanks.
