### PR TITLE
Fix compile error

### DIFF
--- a/main.c
+++ b/main.c
@@ -404,7 +404,7 @@ int main(int argc, char **argv)
 					stb_type = BRCM7401;
 					break;
 				}
-				else if (strcasestr(buf,"DM900")) || (strcasestr(buf,"DM920"))
+				else if (strcasestr(buf,"DM900") || strcasestr(buf,"DM920"))
 				{
 					stb_type = BRCM7439;
 					break;


### PR DESCRIPTION
> | ../git/main.c:407:39: error: expected expression before '||' token
|      else if (strcasestr(buf,"DM900")) || (strcasestr(buf,"DM920"))