### PR TITLE
fix stale OSD on triple-buffered framebuffer (e.g. DM9xx)

### DIFF
--- a/main.c
+++ b/main.c
@@ -2449,6 +2449,26 @@ void getosd(unsigned char *osd, int *xres, int *yres)
 		return;
 		}
 
+	/*
+	 * Triple-buffered framebuffer fix (DM900/DM920, stb_type == BRCM7439):
+	 * Enigma2 rotates OSD pages by panning to Y=0, Y=yres, Y=2*yres.  The
+	 * code below reads from offset 0 in lfb, but the currently-displayed
+	 * frame may be at a higher yoffset.  Fix: memmove the front-buffer page
+	 * to Y=0 in the mmap, then call FBIOPAN_DISPLAY to move the hardware
+	 * pointer to Y=0.  Grab then reads the correct frame and E2 will not
+	 * render into Y=0 while it is the hardware front buffer.
+	 */
+	if (stb_type == BRCM7439 &&
+	    var_screeninfo.yres_virtual > var_screeninfo.yres && var_screeninfo.yoffset != 0)
+	{
+		unsigned long src_off   = (unsigned long)var_screeninfo.yoffset * fix_screeninfo.line_length;
+		unsigned long page_bytes = (unsigned long)var_screeninfo.yres   * fix_screeninfo.line_length;
+		memmove(lfb, lfb + src_off, page_bytes);
+		var_screeninfo.xoffset = 0;
+		var_screeninfo.yoffset = 0;
+		ioctl(fb, FBIOPAN_DISPLAY, &var_screeninfo);
+	}
+
 	if ( var_screeninfo.bits_per_pixel == 32 )
 	{
 		if (!quiet)


### PR DESCRIPTION
The DM900 and DM920 (BCM7439) use a triple-buffered OSD framebuffer with
three pages at Y=0, Y=1080, Y=2160 in /dev/fb0 (yres_virtual=3240).
Enigma2 rotates pages by calling FBIOPAN_DISPLAY after each render.

Root cause:
  getosd() mmaps /dev/fb0 and reads from offset 0 in the mapping.
  However, FBIOGET_VSCREENINFO may report yoffset=1080 or yoffset=2160,
  meaning the currently-displayed frame lives at a higher offset in the
  buffer.  The frame at offset 0 is a back buffer that Enigma2 may be
  actively rendering into, resulting in a stale or partially-drawn OSD
  in the captured screenshot.

Fix:
  In getosd(), after the framebuffer mmap and only for BRCM7439, check
  whether the hardware is displaying a page other than Y=0.  If so:
  1. memmove the currently-displayed page to offset 0 in the mapping.
  2. Call FBIOPAN_DISPLAY(yoffset=0) to move the hardware front-buffer
     pointer to Y=0.

  The grab then reads from offset 0 (the correct frame) and Enigma2
  will not render into Y=0 while it is the hardware front buffer,
  eliminating the race with the page-flip cycle.

  The fix is guarded by stb_type == BRCM7439 so no other platform is
  affected.  The inner guards yres_virtual > yres and yoffset != 0
  make it a no-op when panning is not in use.