### PR TITLE
[aio-grab] fix ffmpeg options for some iptv ssai urls

### DIFF
--- a/main.c
+++ b/main.c
@@ -387,6 +387,27 @@ static void grab_percent_decode_repeat_inplace(char *s, int rounds)
 	}
 }
 
+/*
+ * Collapse only the "%25" -> "%" wrapping layer, in place, repeatedly.
+ *
+ * OpenWebif can wrap an already-encoded IPTV service reference in one more
+ * layer of percent-encoding when it serializes it into XML (turning the
+ * URL's own "%3a" scheme/field colons into "%253a").  Unlike
+ * grab_percent_decode_repeat_inplace(), this does not touch a genuine
+ * single-encoded "%3a" (or any other %XX that is not part of a "%25"
+ * sequence), so it normalizes away that extra transport-layer wrapping
+ * without destroying the encoded-vs-literal-colon distinction that
+ * grab_extract_embedded_stream_url() relies on to find the end of the URL.
+ */
+static void grab_collapse_percent25_inplace(char *s)
+{
+	char *p;
+	if (!s)
+		return;
+	while ((p = strstr(s, "%25")) != NULL)
+		memmove(p + 1, p + 3, strlen(p + 3) + 1);
+}
+
 static void grab_xml_unescape_inplace(char *s)
 {
 	char *d = s;
@@ -685,12 +706,17 @@ static int grab_extract_embedded_stream_url(const char *sref, char *out, size_t 
 		return -1;
 
 	/* OpenWebif can return IPTV service references double-encoded, for example
-	 * http%253a//host%253a8080/... .  Decode a copy repeatedly before looking
-	 * for the embedded URL so we do not accidentally fall back to
-	 * http://127.0.0.1:8001/<whole service reference>. */
+	 * http%253a//host%253a8080/... .  Collapse away only that extra "%25"
+	 * transport-layer wrapping here, not a full percent-decode: the enigma2
+	 * reference format depends on the URL's own colons staying encoded
+	 * ("%3a") so that a literal, unencoded ':' unambiguously marks the
+	 * end-of-URL / service-name separator.  Some SSAI ad-tracking providers
+	 * embed a literal ':' in their own query parameter names (e.g.
+	 * "ads:foo=..."), which decoding too early would make indistinguishable
+	 * from that separator and truncate the URL mid-query-string. */
 	snprintf(work, sizeof(work), "%s", sref);
 	grab_xml_unescape_inplace(work);
-	grab_percent_decode_repeat_inplace(work, 4);
+	grab_collapse_percent25_inplace(work);
 
 	p = grab_find_earliest_url_marker(work, &encoded);
 	if (!p)

--- a/main.c
+++ b/main.c
@@ -1087,6 +1087,29 @@ static void grab_make_ffmpeg_scale_fast(char *dst, size_t dst_len, int out_w, in
 		snprintf(dst, dst_len, "scale=%d:%d:flags=fast_bilinear,format=bgr24", out_w, out_h);
 }
 
+/*
+ * -extension_picky is a private AVOption of ffmpeg's HLS demuxer.  Passing it
+ * for a non-HLS input (a plain DVB/IPTV .ts or .mp4 URL) makes ffmpeg abort
+ * with "Unrecognized option" before it even probes the input, so only add it
+ * when the input actually looks like an .m3u8 playlist.
+ */
+static int grab_input_is_hls(const char *input)
+{
+	const char *q;
+	size_t path_len;
+
+	if (!input)
+		return 0;
+
+	q = strchr(input, '?');
+	path_len = q ? (size_t)(q - input) : strlen(input);
+
+	if (path_len < 5)
+		return 0;
+
+	return !strncasecmp(input + path_len - 5, ".m3u8", 5);
+}
+
 static int grab_run_argv_capture_stdout(char *const argv[], unsigned char *buf, size_t need)
 {
 	int pipefd[2];
@@ -1192,14 +1215,17 @@ static int grab_ffmpeg_decode_bgr24_to_buffer(const char *input, unsigned char *
 	argv[n++] = "-an";
 	argv[n++] = "-sn";
 	argv[n++] = "-dn";
-	/* Some IPTV SSAI providers (e.g. Rakuten/Xumo ad-stitched HLS) wrap segment
-	 * URIs behind analytics beacon redirects that do not end in a recognized
-	 * media extension.  ffmpeg's HLS demuxer rejects those by default
-	 * ("is not in allowed_segment_extensions"), which makes every variant look
-	 * empty and fails stream mapping.  Disable the extension allow-list check
-	 * for this input; the demuxer still requires valid HLS/segment content. */
-	argv[n++] = "-extension_picky";
-	argv[n++] = "0";
+	if (grab_input_is_hls(input))
+	{
+		/* Some IPTV SSAI providers (e.g. Rakuten/Xumo ad-stitched HLS) wrap segment
+		 * URIs behind analytics beacon redirects that do not end in a recognized
+		 * media extension.  ffmpeg's HLS demuxer rejects those by default
+		 * ("is not in allowed_segment_extensions"), which makes every variant look
+		 * empty and fails stream mapping.  Disable the extension allow-list check
+		 * for this input; the demuxer still requires valid HLS/segment content. */
+		argv[n++] = "-extension_picky";
+		argv[n++] = "0";
+	}
 	if (frame_mode == GRAB_FFMPEG_FRAME_KEYONLY)
 	{
 		/*
@@ -1323,20 +1349,8 @@ static int grab_ffmpeg_one_video_image(const char *input, const char *out, int o
 	char vf[96];
 	char qbuf[16];
 	const char *codec = grab_ffmpeg_codec_name(use_png, use_jpg);
-	char *argv_jpg[] = {
-		"/usr/bin/ffmpeg", "-hide_banner", "-loglevel", "error",
-		"-extension_picky", "0",
-		"-i", (char *)input,
-		"-vf", vf, "-vframes", "1",
-		"-movflags", "+faststart", "-f", "image2", "-c:v", (char *)codec, "-q:v", qbuf, "-y", (char *)out, NULL
-	};
-	char *argv_other[] = {
-		"/usr/bin/ffmpeg", "-hide_banner", "-loglevel", "error",
-		"-extension_picky", "0",
-		"-i", (char *)input,
-		"-vf", vf, "-vframes", "1",
-		"-movflags", "+faststart", "-f", "image2", "-c:v", (char *)codec, "-y", (char *)out, NULL
-	};
+	char *argv[24];
+	int n = 0;
 
 	if (!codec)
 		return -1;
@@ -1351,21 +1365,47 @@ static int grab_ffmpeg_one_video_image(const char *input, const char *out, int o
 	 * fps=1/2 lets ffmpeg wait for a decodable HEVC frame instead of failing on
 	 * the first packet after joining the live TS. */
 	snprintf(qbuf, sizeof(qbuf), "%d", grab_ffmpeg_quality_arg(jpg_quality));
-	return grab_run_argv(use_jpg ? argv_jpg : argv_other);
+
+	argv[n++] = "/usr/bin/ffmpeg";
+	argv[n++] = "-hide_banner";
+	argv[n++] = "-loglevel";
+	argv[n++] = "error";
+	if (grab_input_is_hls(input))
+	{
+		argv[n++] = "-extension_picky";
+		argv[n++] = "0";
+	}
+	argv[n++] = "-i";
+	argv[n++] = (char *)input;
+	argv[n++] = "-vf";
+	argv[n++] = vf;
+	argv[n++] = "-vframes";
+	argv[n++] = "1";
+	argv[n++] = "-movflags";
+	argv[n++] = "+faststart";
+	argv[n++] = "-f";
+	argv[n++] = "image2";
+	argv[n++] = "-c:v";
+	argv[n++] = (char *)codec;
+	if (use_jpg)
+	{
+		argv[n++] = "-q:v";
+		argv[n++] = qbuf;
+	}
+	argv[n++] = "-y";
+	argv[n++] = (char *)out;
+	argv[n++] = NULL;
+
+	return grab_run_argv(argv);
 }
 
 static int grab_ffmpeg_one_video_bmp(const char *input, const char *out, int out_w, int out_h)
 {
 	char vf[96];
 	char raw_tmp[128];
+	char *argv[20];
+	int n = 0;
 	int ret;
-	char *argv[] = {
-		"/usr/bin/ffmpeg", "-hide_banner", "-loglevel", "error",
-		"-extension_picky", "0",
-		"-i", (char *)input,
-		"-vf", vf, "-vframes", "1",
-		"-f", "rawvideo", "-pix_fmt", "bgr24", "-y", raw_tmp, NULL
-	};
 
 	if (out_w <= 0)
 		out_w = 1920;
@@ -1377,6 +1417,29 @@ static int grab_ffmpeg_one_video_bmp(const char *input, const char *out, int out
 	grab_make_ffmpeg_scale(vf, sizeof(vf), out_w, out_h, 1);
 	snprintf(raw_tmp, sizeof(raw_tmp), "/tmp/grab-ffmpeg-%ld-video.bgr", (long)getpid());
 	unlink(raw_tmp);
+
+	argv[n++] = "/usr/bin/ffmpeg";
+	argv[n++] = "-hide_banner";
+	argv[n++] = "-loglevel";
+	argv[n++] = "error";
+	if (grab_input_is_hls(input))
+	{
+		argv[n++] = "-extension_picky";
+		argv[n++] = "0";
+	}
+	argv[n++] = "-i";
+	argv[n++] = (char *)input;
+	argv[n++] = "-vf";
+	argv[n++] = vf;
+	argv[n++] = "-vframes";
+	argv[n++] = "1";
+	argv[n++] = "-f";
+	argv[n++] = "rawvideo";
+	argv[n++] = "-pix_fmt";
+	argv[n++] = "bgr24";
+	argv[n++] = "-y";
+	argv[n++] = raw_tmp;
+	argv[n++] = NULL;
 
 	ret = grab_run_argv(argv);
 	if (ret == 0)

--- a/main.c
+++ b/main.c
@@ -1211,7 +1211,7 @@ static int grab_run_argv_capture_stdout(char *const argv[], unsigned char *buf, 
 	return 0;
 }
 
-static int grab_ffmpeg_decode_bgr24_to_buffer(const char *input, unsigned char *video, int out_w, int out_h, int frame_mode)
+static int grab_ffmpeg_decode_bgr24_to_buffer(const char *input, unsigned char *video, int out_w, int out_h, int frame_mode, int force_extension_picky)
 {
 	char vf[128];
 	const char *loglevel = grab_ffmpeg_loglevel();
@@ -1241,14 +1241,17 @@ static int grab_ffmpeg_decode_bgr24_to_buffer(const char *input, unsigned char *
 	argv[n++] = "-an";
 	argv[n++] = "-sn";
 	argv[n++] = "-dn";
-	if (grab_input_is_hls(input))
+	if (grab_input_is_hls(input) || force_extension_picky)
 	{
 		/* Some IPTV SSAI providers (e.g. Rakuten/Xumo ad-stitched HLS) wrap segment
 		 * URIs behind analytics beacon redirects that do not end in a recognized
 		 * media extension.  ffmpeg's HLS demuxer rejects those by default
 		 * ("is not in allowed_segment_extensions"), which makes every variant look
 		 * empty and fails stream mapping.  Disable the extension allow-list check
-		 * for this input; the demuxer still requires valid HLS/segment content. */
+		 * for this input; the demuxer still requires valid HLS/segment content.
+		 * force_extension_picky is set when the caller is retrying an input that
+		 * doesn't visibly look like HLS (e.g. an opaque jmp2.uk-style redirector
+		 * URL with no ".m3u8" in it) after a plain attempt already failed. */
 		argv[n++] = "-extension_picky";
 		argv[n++] = "0";
 	}
@@ -1333,25 +1336,39 @@ static int grab_ffmpeg_getvideo_frame(unsigned char *video, int *xres, int *yres
 		 */
 		if (!quiet)
 			fprintf(stderr, "ffmpeg backend: HEVC DVB stream, waiting for next key frame\n");
-		ret = grab_ffmpeg_decode_bgr24_to_buffer(input, video, out_w, out_h, GRAB_FFMPEG_FRAME_KEYONLY);
+		ret = grab_ffmpeg_decode_bgr24_to_buffer(input, video, out_w, out_h, GRAB_FFMPEG_FRAME_KEYONLY, 0);
 		if (ret < 0)
 		{
 			if (!quiet)
 				fprintf(stderr, "ffmpeg backend: key-frame grab failed, retrying with fps=1/2 wait mode\n");
-			ret = grab_ffmpeg_decode_bgr24_to_buffer(input, video, out_w, out_h, GRAB_FFMPEG_FRAME_WAIT);
+			ret = grab_ffmpeg_decode_bgr24_to_buffer(input, video, out_w, out_h, GRAB_FFMPEG_FRAME_WAIT, 0);
 		}
 	}
 	else
 	{
 		/* Fast path first: no fps=1/2 throttle.  If the live join starts before
 		 * a clean access unit, retry once with the slower DreamOS-style wait filter. */
-		ret = grab_ffmpeg_decode_bgr24_to_buffer(input, video, out_w, out_h, GRAB_FFMPEG_FRAME_FAST);
+		ret = grab_ffmpeg_decode_bgr24_to_buffer(input, video, out_w, out_h, GRAB_FFMPEG_FRAME_FAST, 0);
 		if (ret < 0)
 		{
 			if (!quiet)
 				fprintf(stderr, "ffmpeg backend: fast frame failed, retrying with fps=1/2 wait mode\n");
-			ret = grab_ffmpeg_decode_bgr24_to_buffer(input, video, out_w, out_h, GRAB_FFMPEG_FRAME_WAIT);
+			ret = grab_ffmpeg_decode_bgr24_to_buffer(input, video, out_w, out_h, GRAB_FFMPEG_FRAME_WAIT, 0);
 		}
+	}
+
+	if (ret < 0 && !grab_input_is_hls(input))
+	{
+		/* The input may be an opaque redirector/shortener URL (e.g. a
+		 * jmp2.uk-style link with no visible ".m3u8") whose real target is
+		 * HLS with beacon-wrapped segments, which grab_input_is_hls() can't
+		 * detect up front.  Retry once forcing the extension allow-list off.
+		 * If the input genuinely isn't HLS this attempt fails independently
+		 * (possibly with ffmpeg's own "Unrecognized option" for a private
+		 * HLS option), which is no worse than the failure already in ret. */
+		if (!quiet)
+			fprintf(stderr, "ffmpeg backend: retrying in case input is HLS behind a redirector (extension_picky off)\n");
+		ret = grab_ffmpeg_decode_bgr24_to_buffer(input, video, out_w, out_h, GRAB_FFMPEG_FRAME_WAIT, 1);
 	}
 
 	if (ret == 0)
@@ -1370,7 +1387,7 @@ static void grab_make_ffmpeg_scale(char *dst, size_t dst_len, int out_w, int out
 		snprintf(dst, dst_len, "fps=1/2,scale=%d:%d", out_w, out_h);
 }
 
-static int grab_ffmpeg_one_video_image(const char *input, const char *out, int out_w, int out_h, int use_png, int use_jpg, int jpg_quality)
+static int grab_ffmpeg_one_video_image_try(const char *input, const char *out, int out_w, int out_h, int use_png, int use_jpg, int jpg_quality, int force_extension_picky)
 {
 	char vf[96];
 	char qbuf[16];
@@ -1380,12 +1397,6 @@ static int grab_ffmpeg_one_video_image(const char *input, const char *out, int o
 
 	if (!codec)
 		return -1;
-	if (out_w <= 0)
-		out_w = 1920;
-	if (out_h <= 0)
-		out_h = (out_w * 9) / 16;
-	if (out_h & 1)
-		out_h++;
 	grab_make_ffmpeg_scale(vf, sizeof(vf), out_w, out_h, 0);
 	/* Match DreamOS FreezeFrame behaviour on armhf: no tiny analyzeduration/probesize.
 	 * fps=1/2 lets ffmpeg wait for a decodable HEVC frame instead of failing on
@@ -1396,7 +1407,7 @@ static int grab_ffmpeg_one_video_image(const char *input, const char *out, int o
 	argv[n++] = "-hide_banner";
 	argv[n++] = "-loglevel";
 	argv[n++] = "error";
-	if (grab_input_is_hls(input))
+	if (grab_input_is_hls(input) || force_extension_picky)
 	{
 		argv[n++] = "-extension_picky";
 		argv[n++] = "0";
@@ -1425,12 +1436,8 @@ static int grab_ffmpeg_one_video_image(const char *input, const char *out, int o
 	return grab_run_argv(argv);
 }
 
-static int grab_ffmpeg_one_video_bmp(const char *input, const char *out, int out_w, int out_h)
+static int grab_ffmpeg_one_video_image(const char *input, const char *out, int out_w, int out_h, int use_png, int use_jpg, int jpg_quality)
 {
-	char vf[96];
-	char raw_tmp[128];
-	char *argv[20];
-	int n = 0;
 	int ret;
 
 	if (out_w <= 0)
@@ -1440,15 +1447,29 @@ static int grab_ffmpeg_one_video_bmp(const char *input, const char *out, int out
 	if (out_h & 1)
 		out_h++;
 
-	grab_make_ffmpeg_scale(vf, sizeof(vf), out_w, out_h, 1);
-	snprintf(raw_tmp, sizeof(raw_tmp), "/tmp/grab-ffmpeg-%ld-video.bgr", (long)getpid());
-	unlink(raw_tmp);
+	ret = grab_ffmpeg_one_video_image_try(input, out, out_w, out_h, use_png, use_jpg, jpg_quality, 0);
+	if (ret < 0 && !grab_input_is_hls(input))
+	{
+		/* Input may be an opaque redirector URL (no visible ".m3u8") whose
+		 * real target is HLS with beacon-wrapped segments; see the matching
+		 * retry in grab_ffmpeg_getvideo_frame(). */
+		if (!quiet)
+			fprintf(stderr, "ffmpeg backend: retrying in case input is HLS behind a redirector (extension_picky off)\n");
+		ret = grab_ffmpeg_one_video_image_try(input, out, out_w, out_h, use_png, use_jpg, jpg_quality, 1);
+	}
+	return ret;
+}
+
+static int grab_ffmpeg_one_video_bmp_try(const char *input, const char *raw_tmp, char *vf, int force_extension_picky)
+{
+	char *argv[20];
+	int n = 0;
 
 	argv[n++] = "/usr/bin/ffmpeg";
 	argv[n++] = "-hide_banner";
 	argv[n++] = "-loglevel";
 	argv[n++] = "error";
-	if (grab_input_is_hls(input))
+	if (grab_input_is_hls(input) || force_extension_picky)
 	{
 		argv[n++] = "-extension_picky";
 		argv[n++] = "0";
@@ -1464,10 +1485,36 @@ static int grab_ffmpeg_one_video_bmp(const char *input, const char *out, int out
 	argv[n++] = "-pix_fmt";
 	argv[n++] = "bgr24";
 	argv[n++] = "-y";
-	argv[n++] = raw_tmp;
+	argv[n++] = (char *)raw_tmp;
 	argv[n++] = NULL;
 
-	ret = grab_run_argv(argv);
+	return grab_run_argv(argv);
+}
+
+static int grab_ffmpeg_one_video_bmp(const char *input, const char *out, int out_w, int out_h)
+{
+	char vf[96];
+	char raw_tmp[128];
+	int ret;
+
+	if (out_w <= 0)
+		out_w = 1920;
+	if (out_h <= 0)
+		out_h = (out_w * 9) / 16;
+	if (out_h & 1)
+		out_h++;
+
+	grab_make_ffmpeg_scale(vf, sizeof(vf), out_w, out_h, 1);
+	snprintf(raw_tmp, sizeof(raw_tmp), "/tmp/grab-ffmpeg-%ld-video.bgr", (long)getpid());
+	unlink(raw_tmp);
+
+	ret = grab_ffmpeg_one_video_bmp_try(input, raw_tmp, vf, 0);
+	if (ret < 0 && !grab_input_is_hls(input))
+	{
+		if (!quiet)
+			fprintf(stderr, "ffmpeg backend: retrying in case input is HLS behind a redirector (extension_picky off)\n");
+		ret = grab_ffmpeg_one_video_bmp_try(input, raw_tmp, vf, 1);
+	}
 	if (ret == 0)
 		ret = grab_raw_bgr24_file_to_bmp(raw_tmp, out, out_w, out_h);
 	unlink(raw_tmp);

--- a/main.c
+++ b/main.c
@@ -1192,6 +1192,14 @@ static int grab_ffmpeg_decode_bgr24_to_buffer(const char *input, unsigned char *
 	argv[n++] = "-an";
 	argv[n++] = "-sn";
 	argv[n++] = "-dn";
+	/* Some IPTV SSAI providers (e.g. Rakuten/Xumo ad-stitched HLS) wrap segment
+	 * URIs behind analytics beacon redirects that do not end in a recognized
+	 * media extension.  ffmpeg's HLS demuxer rejects those by default
+	 * ("is not in allowed_segment_extensions"), which makes every variant look
+	 * empty and fails stream mapping.  Disable the extension allow-list check
+	 * for this input; the demuxer still requires valid HLS/segment content. */
+	argv[n++] = "-extension_picky";
+	argv[n++] = "0";
 	if (frame_mode == GRAB_FFMPEG_FRAME_KEYONLY)
 	{
 		/*
@@ -1317,12 +1325,14 @@ static int grab_ffmpeg_one_video_image(const char *input, const char *out, int o
 	const char *codec = grab_ffmpeg_codec_name(use_png, use_jpg);
 	char *argv_jpg[] = {
 		"/usr/bin/ffmpeg", "-hide_banner", "-loglevel", "error",
+		"-extension_picky", "0",
 		"-i", (char *)input,
 		"-vf", vf, "-vframes", "1",
 		"-movflags", "+faststart", "-f", "image2", "-c:v", (char *)codec, "-q:v", qbuf, "-y", (char *)out, NULL
 	};
 	char *argv_other[] = {
 		"/usr/bin/ffmpeg", "-hide_banner", "-loglevel", "error",
+		"-extension_picky", "0",
 		"-i", (char *)input,
 		"-vf", vf, "-vframes", "1",
 		"-movflags", "+faststart", "-f", "image2", "-c:v", (char *)codec, "-y", (char *)out, NULL
@@ -1351,6 +1361,7 @@ static int grab_ffmpeg_one_video_bmp(const char *input, const char *out, int out
 	int ret;
 	char *argv[] = {
 		"/usr/bin/ffmpeg", "-hide_banner", "-loglevel", "error",
+		"-extension_picky", "0",
 		"-i", (char *)input,
 		"-vf", vf, "-vframes", "1",
 		"-f", "rawvideo", "-pix_fmt", "bgr24", "-y", raw_tmp, NULL


### PR DESCRIPTION
Problem: 
aio-grab fails to grab video screenshot from Rakuten TV stream.

Reason:
Some IPTV SSAI providers (e.g. Rakuten/Xumo ad-stitched HLS) wrap segment
URIs behind analytics beacon redirects that do not end in a recognized
media extension.  ffmpeg's HLS demuxer rejects those by default
("is not in allowed_segment_extensions"), which makes every variant look
empty and fails stream mapping.

Fix:
add "-extension_picky" to ffmpeg parameter list.

Remarks:
- fix was created by claude code
- fix was verified to work with Rakuten TV stream that failed before.